### PR TITLE
Add deconjugation support and key bindings to switch dict in definition_select

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ the [change log](/CHANGELOG.md).
    contents of `jmdict_english.zip` from the Yomichan website.
 6. To enable deconjugation download deconjugation file from 
    [here](https://mega.nz/#F!eyYwyIgY!3q4XQ3BhdvkFg9KsPe5avw!bz4ywa5A) and change
-   the location `conjugation_dict' to the path of deconjugation file.
+   the value of `conjugation_dict` so it is set to the path of the deconjugation file you just downloaded.
 
 Your mpv config directory should contain the following files at this point:
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ the [change log](/CHANGELOG.md).
    contents of `jmdict_english.zip` from the Yomichan website.
 6. To enable deconjugation download deconjugation file from 
    [here](https://mega.nz/#F!eyYwyIgY!3q4XQ3BhdvkFg9KsPe5avw!bz4ywa5A) and change
-   the value of `conjugation_dict` so it is set to the path of the deconjugation file you just downloaded.
+   the value of `conjugation_dict` in [`immersive.conf`](/doc/script-config.md) so it is set to the path of the deconjugation file you just downloaded.
 
 Your mpv config directory should contain the following files at this point:
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ the [change log](/CHANGELOG.md).
    the Yomichan version of JMdict, you will most likely only have to change
    `location` so it is set to the path of a directory containing the unzipped
    contents of `jmdict_english.zip` from the Yomichan website.
+6. To enable deconjugation download deconjugation file from 
+   [here](https://mega.nz/#F!eyYwyIgY!3q4XQ3BhdvkFg9KsPe5avw!bz4ywa5A) and change
+   the location `conjugation_dict' to the path of deconjugation file.
 
 Your mpv config directory should contain the following files at this point:
 

--- a/doc/keys.md
+++ b/doc/keys.md
@@ -67,9 +67,11 @@ Available after opening the active line menu with `k`.
 
 Available while selecting a definition after a dictionary search.
 
-| ID         | Key      | Action                  |
-| ---------- | -------- | ----------------------- |
-| `confirm`  | `ENTER`  | use selected definition |
+| ID               | Key        | Action                             |
+| ---------------- | ---------- | ---------------------------------- |
+| `confirm`        | `ENTER`    | use selected definition            |
+| `prev_dict`      | `Alt+UP`   | switch to the previous dictionary  |
+| `next_dict`      | `Alt+DOWN` | switch to the next dictionary      |
 
 ---
 

--- a/doc/script-config.md
+++ b/doc/script-config.md
@@ -78,4 +78,9 @@ Some general config options are located in `immersive.conf`:
 # Hide the menu info at the bottom left if the help overlay is active.
 # Useful if the two collide due to large font sizes.
 #hide_infos_if_help_active=no
+
+# download deconjugation file from here https://mega.nz/#F!eyYwyIgY!3q4XQ3BhdvkFg9KsPe5avw!bz4ywa5A by migaku
+# empty to disable deconjugation
+# location to deconjugation file
+#conjugation_dict=
 ```

--- a/interface/definition_select.lua
+++ b/interface/definition_select.lua
@@ -114,13 +114,13 @@ function DefinitionSelect:new(word, prefix, data)
 			id = "prev_dict",
 			default = "Alt+UP",
 			desc = "Switch to the previous dictionary",
-			action = function() dicts.switch(-1); ds.menu:redraw(); menu_stack.pop(); menu_stack.push(DefinitionSelect:new(word, prefix)) end
+			action = function() dicts.switch(-1); ds.menu:redraw(); menu_stack.pop(); menu_stack.push(DefinitionSelect:new(word, prefix, data)) end
 		},
 		{
 			id = "next_dict",
 			default = "Alt+DOWN",
 			desc = "Switch to the next dictionary",
-			action = function() dicts.switch(1); ds.menu:redraw(); menu_stack.pop(); menu_stack.push(DefinitionSelect:new(word, prefix)) end
+			action = function() dicts.switch(1); ds.menu:redraw(); menu_stack.pop(); menu_stack.push(DefinitionSelect:new(word, prefix, data)) end
 		}
 	}
 

--- a/systems/config.lua
+++ b/systems/config.lua
@@ -40,7 +40,8 @@ local config = {
 		global_help = true,
 		enable_help = false,
 		take_screenshots = true,
-		hide_infos_if_help_active = false
+		hide_infos_if_help_active = false,
+		conjugation_dict = ""
 	}
 }
 


### PR DESCRIPTION
## Deconjugation support
Dictionary will not return definition for conjugated word like 泣いて. Deconjugation support is based on [this](https://github.com/migaku-official/Migaku-Dictionary-Addon/blob/640c136d2f4d11d8e6ad48775e0a8046855055fb/src/dictdb.py#L219).

## Key bindings to switch dictionary in definition_select 
I found it annoying that I need to press `ctrl+shift+a` `alt+up` `esc` `esc` `enter` every time to switch dictionary when I don't understand the definition or want an alternative explanation. This PR will add key bindings to switch dictionary directly in definition_select: `alt + up` and `alt + down`

### Thank you
I want to say thank you for developing immersive. Immersive makes my sentence mining workflow a lot easier and faster compared to [my old workflow](https://animecards.site/minefromanime/). I'm not an experienced programmer so apologies for any mistakes or ugly code in PR. You can edit or discard the PR if you see fit.